### PR TITLE
Support conversation source from Docs

### DIFF
--- a/src/Model/Conversation.cs
+++ b/src/Model/Conversation.cs
@@ -46,7 +46,8 @@ namespace HelpScoutNet.Model
         emailfwd,
         api,
         chat,
-        workflows
+        workflows,
+        docs
     }
     
     public class Attachment


### PR DESCRIPTION
Got a Newtonsoft JSON Deserialize error when fetching conversations when a message originated from a Docs source - i.e. someone was on the Help Scout Docs site and clicked the Contact link.
