### PR TITLE
Add support for TLS 1.1 and 1.2 and revert to .NET 4.5

### DIFF
--- a/src/HelpScoutClient.cs
+++ b/src/HelpScoutClient.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using HelpScoutNet.Request.Report;
 using System.Threading.Tasks;
+using System.Net;
 
 namespace HelpScoutNet
 {
@@ -559,6 +560,8 @@ namespace HelpScoutNet
 
         private HttpClient InitHttpClient()
         {
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+
             var client = new HttpClient();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
                 Convert.ToBase64String(ASCIIEncoding.ASCII.GetBytes(string.Format("{0}:{1}", _apiKey, "X"))));

--- a/src/HelpScoutNet.csproj
+++ b/src/HelpScoutNet.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HelpScoutNet</RootNamespace>
     <AssemblyName>HelpScoutNet</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
The change to .NET 4.6 is problematic (or at least quite cumbersome) for some Azure Cloud Service deployments that don't have 4.6 already installed.

This change addresses the removal of TLS 1.0 support from HelpScout, and reverts the .NET minimum dependency to 4.5.