### PR TITLE
adding "hidden" thread type

### DIFF
--- a/src/Model/Thread.cs
+++ b/src/Model/Thread.cs
@@ -33,7 +33,8 @@ namespace HelpScoutNet.Model
     {
         published,
         draft,
-        underreview
+        underreview,
+        hidden
     }
 
     public enum ThreadStatus


### PR DESCRIPTION
JSON parsing fails because its missing this thread type:

![image](https://user-images.githubusercontent.com/6180562/40688538-d752d0d4-6374-11e8-9430-9580222b5cd5.png)

Thread type is mentioned in HS API guide: https://developer.helpscout.com/help-desk-api/objects/thread/
