### PR TITLE
Updated Thread Model property Id to be double

### DIFF
--- a/src/Model/Thread.cs
+++ b/src/Model/Thread.cs
@@ -9,7 +9,7 @@ namespace HelpScoutNet.Model
 {
     public class Thread
     {
-        public int Id { get; set; }
+        public double Id { get; set; }
         public Person AssignedTo { get; set; }
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Include)]
         public ThreadStatus Status { get; set; }


### PR DESCRIPTION
This is due to Helpscout hitting the limit for int with threads. 